### PR TITLE
test: fix snapshot

### DIFF
--- a/src/snapshots/md_lsp__state__tests__index_md_files.snap
+++ b/src/snapshots/md_lsp__state__tests__index_md_files.snap
@@ -3,6 +3,7 @@ source: src/state.rs
 expression: file_names
 ---
 [
+    "CHANGELOG.md",
     "README.md",
     "testdata/test file c.md",
     "testdata/test-file-b.md",


### PR DESCRIPTION
Creating the release added `CHANGELOG.md` which broke the test snapshots. This is to fix that. Might need something more permanent later on to stop this from happening in the future.

Could you create a v0.1.1 release after this gets merged as well? Thanks!